### PR TITLE
feat: add Linux build support (DEB, RPM, AppImage)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,18 @@ jobs:
         include:
           - platform: 'windows-latest'
             args: ''
+          - platform: 'ubuntu-22.04'
+            args: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf rpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,13 +29,26 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
+    "shortDescription": "Search and manage VRChat items from Booth.pm",
+    "category": "Utility",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "linux": {
+      "deb": {
+        "depends": [],
+        "section": "utility",
+        "priority": "optional"
+      },
+      "rpm": {
+        "depends": [],
+        "release": "1"
+      }
+    }
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
# Summary
- Add Linux (ubuntu-22.04) to CI/CD publish workflow alongside Windows
- Configure DEB, RPM, and AppImage bundle metadata in Tauri config
- Linux artifacts will be included in draft GitHub releases automatically
 # Changes
- **Modified**: `.github/workflows/publish.yml` — added `ubuntu-22.04` to build matrix, added conditional step to install Linux system dependencies (`libwebkit2gtk-4.1-dev`, `libappindicator3-dev`, `librsvg2-dev`, `patchelf`, `rpm`)
- **Modified**: `src-tauri/tauri.conf.json` — added `shortDescription`, `category`, and `bundle.linux` config with DEB (`section`, `priority`) and RPM (`release`) metadata

> **This PR description is hand-written, not by LLM**